### PR TITLE
Update chromedriver version in report2.yml

### DIFF
--- a/.github/workflows/report2.yml
+++ b/.github/workflows/report2.yml
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pillow pytesseract requests selenium
-        wget https://chromedriver.storage.googleapis.com/104.0.5112.79/chromedriver_linux64.zip
+        wget https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_linux64.zip
         unzip chromedriver_linux64.zip
         sudo cp chromedriver /usr/bin
         wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
现在下载的chrome版本为106，旧版本chromedriver会无法成功截图xck，导致只能上传默认图片。